### PR TITLE
Add docker-compose definition

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:latest
+
+CMD ["mysqld"]
+
+EXPOSE 3306

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.3'
+services:
+  web:
+    build:
+      context: ./nginx
+    hostname: local.phalconsimpleskeleton.com
+    volumes:
+      - ../:/var/www
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/sites/:/etc/nginx/sites-available
+      - ./nginx/conf.d/:/etc/nginx/conf.d
+    depends_on:
+      - php
+    ports:
+      - "80:80"
+      - "443:443"
+
+  php:
+    build:
+      context: ./phalcon-php
+    working_dir: /var/www
+    user: 1000:1000
+    volumes:
+      - ../:/var/www
+
+  database:
+    build:
+      context: ./database
+    environment:
+      - MYSQL_DATABASE=mydb
+      - MYSQL_USER=myuser
+      - MYSQL_PASSWORD=secret
+      - MYSQL_ROOT_PASSWORD=docker

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+CMD ["nginx"]
+
+EXPOSE 80 443

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,0 +1,3 @@
+upstream php-upstream {
+    server php:9000;
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  4;
+daemon off;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log  /var/log/nginx/access.log;
+    #access_log /dev/stdout;
+    #error_log /dev/stderr;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-available/*.conf;
+}

--- a/docker/nginx/sites/default.conf
+++ b/docker/nginx/sites/default.conf
@@ -1,0 +1,38 @@
+error_log  /var/www/logs/error.log;
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
+
+    index index.php index.html;
+    server_name local.mymicrocerts.com;
+    access_log /var/www/logs/access.log;
+    root /var/www/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?_url=$uri&$args;
+    }
+    
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php-upstream;
+        fastcgi_index index.php;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_read_timeout 600;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt/;
+        log_not_found off;
+    }
+}

--- a/docker/phalcon-php/Dockerfile
+++ b/docker/phalcon-php/Dockerfile
@@ -1,0 +1,9 @@
+FROM phalconphp/php-fpm
+
+RUN apt-get update && \
+	apt-get install git zip -y && \
+	apt-get autoremove -y
+
+CMD ["php-fpm"]
+
+EXPOSE 9000


### PR DESCRIPTION
This pull request adds a docker support to running the skeleton application from a single docker-compose command.

This docker-compose file have a nginx + php-fpm + database containers. The nginx configuration file could be modified for any uses cases as you need. It is just a simple configuration for general purpose.

The database layer is added for convenience because the majority of applications need a database layer. It could be removed easily.

To run this docker environment you need to run `docker-compose -f docker/docker-compose.yml up -d`